### PR TITLE
close db connections to avoid flooding db

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -1,6 +1,6 @@
 const SQL = require('@nearform/sql')
 const {
-  getDatabase,
+  withDatabase,
   getExpiryConfig,
   getTimeZone,
   runIfDev
@@ -67,17 +67,18 @@ async function removeOldNoticesKeys(client, noticeLifetime) {
 }
 
 exports.handler = async function() {
-  const client = await getDatabase()
   const {
     codeLifetime,
     tokenLifetime,
     noticeLifetime
   } = await getExpiryConfig()
 
-  await createRegistrationMetrics(client)
-  await removeExpiredCodes(client, codeLifetime)
-  await removeExpiredTokens(client, tokenLifetime)
-  await removeOldNoticesKeys(client, noticeLifetime)
+  await withDatabase(async client => {
+    await createRegistrationMetrics(client)
+    await removeExpiredCodes(client, codeLifetime)
+    await removeExpiredTokens(client, tokenLifetime)
+    await removeOldNoticesKeys(client, noticeLifetime)
+  })
 
   return true
 }

--- a/download.js
+++ b/download.js
@@ -128,7 +128,13 @@ exports.handler = async function() {
             `added ${data.exposures.length} exposures from batch ${batchTag}`
           )
         } else if (response.status === 204) {
-          await insertMetric(client, 'INTEROP_KEYS_DOWNLOADED', '', '', inserted)
+          await insertMetric(
+            client,
+            'INTEROP_KEYS_DOWNLOADED',
+            '',
+            '',
+            inserted
+          )
 
           more = false
           console.log('no more batches to download')

--- a/exposures.js
+++ b/exposures.js
@@ -4,8 +4,8 @@ const crypto = require('crypto')
 const protobuf = require('protobufjs')
 const SQL = require('@nearform/sql')
 const {
+  withDatabase,
   getAssetsBucket,
-  getDatabase,
   getExposuresConfig,
   runIfDev
 } = require('./utils')
@@ -338,21 +338,22 @@ async function uploadExposuresSince(client, s3, bucket, config, since) {
 
 exports.handler = async function() {
   const s3 = new AWS.S3({ region: process.env.AWS_REGION })
-  const client = await getDatabase()
   const bucket = await getAssetsBucket()
   const config = await getExposuresConfig()
   const date = new Date()
 
-  await uploadExposuresSince(client, s3, bucket, config, date)
-
-  date.setHours(0, 0, 0, 0)
-
-  for (let i = 0; i < 14; i++) {
+  await withDatabase(async client => {
     await uploadExposuresSince(client, s3, bucket, config, date)
-    date.setDate(date.getDate() - 1)
-  }
 
-  await clearExpiredExposures(client, s3, bucket)
+    date.setHours(0, 0, 0, 0)
+
+    for (let i = 0; i < 14; i++) {
+      await uploadExposuresSince(client, s3, bucket, config, date)
+      date.setDate(date.getDate() - 1)
+    }
+
+    await clearExpiredExposures(client, s3, bucket)
+  })
 
   return true
 }

--- a/settings.js
+++ b/settings.js
@@ -3,7 +3,11 @@ const SQL = require('@nearform/sql')
 const crypto = require('crypto')
 const querystring = require('querystring')
 const { unflatten } = require('flat')
-const { getAssetsBucket, getDatabase, runIfDev } = require('./utils')
+const {
+  withDatabase,
+  getAssetsBucket,
+  runIfDev
+} = require('./utils')
 
 async function getSettingsBody(client) {
   const sql = SQL`SELECT is_language, settings_key, settings_value FROM settings`
@@ -69,18 +73,20 @@ async function updateIfChanged(s3, bucket, key, data) {
 
 exports.handler = async function() {
   const s3 = new AWS.S3({ region: process.env.AWS_REGION })
-  const client = await getDatabase()
   const bucket = await getAssetsBucket()
-  const { exposures, language } = await getSettingsBody(client)
 
-  await updateIfChanged(s3, bucket, 'exposures.json', exposures)
-  await updateIfChanged(s3, bucket, 'language.json', language)
-  await updateIfChanged(s3, bucket, 'settings.json', {
-    ...exposures,
-    ...language
+  return await withDatabase(async client => {
+    const { exposures, language } = await getSettingsBody(client)
+
+    await updateIfChanged(s3, bucket, 'exposures.json', exposures)
+    await updateIfChanged(s3, bucket, 'language.json', language)
+    await updateIfChanged(s3, bucket, 'settings.json', {
+      ...exposures,
+      ...language
+    })
+
+    return { exposures, language }
   })
-
-  return { exposures, language }
 }
 
 runIfDev(exports.handler)

--- a/settings.js
+++ b/settings.js
@@ -3,11 +3,7 @@ const SQL = require('@nearform/sql')
 const crypto = require('crypto')
 const querystring = require('querystring')
 const { unflatten } = require('flat')
-const {
-  withDatabase,
-  getAssetsBucket,
-  runIfDev
-} = require('./utils')
+const { withDatabase, getAssetsBucket, runIfDev } = require('./utils')
 
 async function getSettingsBody(client) {
   const sql = SQL`SELECT is_language, settings_key, settings_value FROM settings`

--- a/token.js
+++ b/token.js
@@ -1,6 +1,10 @@
 const jwt = require('jsonwebtoken')
 const SQL = require('@nearform/sql')
-const { getDatabase, getJwtSecret, runIfDev } = require('./utils')
+const {
+  withDatabase,
+  getJwtSecret,
+  runIfDev
+} = require('./utils')
 
 exports.handler = async function(event) {
   const { description, type } = event
@@ -15,16 +19,18 @@ exports.handler = async function(event) {
     RETURNING id`
 
   const secret = await getJwtSecret()
-  const client = await getDatabase()
-  const { rowCount, rows } = await client.query(sql)
 
-  if (rowCount === 0) {
-    throw new Error('Unable to create token')
-  }
+  return await withDatabase(async client => {
+    const { rowCount, rows } = await client.query(sql)
 
-  const [{ id }] = rows
+    if (rowCount === 0) {
+      throw new Error('Unable to create token')
+    }
 
-  return jwt.sign({ id }, secret)
+    const [{ id }] = rows
+
+    return jwt.sign({ id }, secret)
+  })
 }
 
 runIfDev(exports.handler)

--- a/token.js
+++ b/token.js
@@ -1,10 +1,6 @@
 const jwt = require('jsonwebtoken')
 const SQL = require('@nearform/sql')
-const {
-  withDatabase,
-  getJwtSecret,
-  runIfDev
-} = require('./utils')
+const { withDatabase, getJwtSecret, runIfDev } = require('./utils')
 
 exports.handler = async function(event) {
   const { description, type } = event

--- a/upload.js
+++ b/upload.js
@@ -2,7 +2,7 @@ const fetch = require('node-fetch')
 const SQL = require('@nearform/sql')
 const { JWK, JWS } = require('node-jose')
 const {
-  getDatabase,
+  withDatabase,
   getInteropConfig,
   insertMetric,
   runIfDev
@@ -49,85 +49,86 @@ async function getExposures(client, since) {
 
 exports.handler = async function() {
   const { servers } = await getInteropConfig()
-  const client = await getDatabase()
 
-  for (const { id, privateKey, token, url } of servers) {
-    console.log(`beginning upload to ${id}`)
+  await withDatabase(async client => {
+    for (const { id, privateKey, token, url } of servers) {
+      console.log(`beginning upload to ${id}`)
 
-    const firstExposureId = await getFirstExposureId(client, id)
-    const exposures = await getExposures(client, firstExposureId)
+      const firstExposureId = await getFirstExposureId(client, id)
+      const exposures = await getExposures(client, firstExposureId)
 
-    if (exposures.length === 0) {
-      console.log('no exposures to upload')
-    } else {
-      await client.query('BEGIN')
+      if (exposures.length === 0) {
+        console.log('no exposures to upload')
+      } else {
+        await client.query('BEGIN')
 
-      try {
-        const lastExposureId = exposures[exposures.length - 1].id
+        try {
+          const lastExposureId = exposures[exposures.length - 1].id
 
-        const batchTag = await createBatch(
-          client,
-          exposures.length,
-          lastExposureId,
-          id
-        )
+          const batchTag = await createBatch(
+            client,
+            exposures.length,
+            lastExposureId,
+            id
+          )
 
-        const key = await JWK.asKey(privateKey, 'pem')
-        const sign = JWS.createSign({ format: 'compact' }, key)
+          const key = await JWK.asKey(privateKey, 'pem')
+          const sign = JWS.createSign({ format: 'compact' }, key)
 
-        const payload = exposures.map(
-          ({
-            key_data: keyData,
-            rolling_start_number: rollingStartNumber,
-            transmission_risk_level: transmissionRiskLevel,
-            rolling_period: rollingPeriod,
-            regions
-          }) => ({
-            keyData,
-            rollingStartNumber,
-            transmissionRiskLevel,
-            rollingPeriod,
-            regions
+          const payload = exposures.map(
+            ({
+              key_data: keyData,
+              rolling_start_number: rollingStartNumber,
+              transmission_risk_level: transmissionRiskLevel,
+              rolling_period: rollingPeriod,
+              regions
+            }) => ({
+              keyData,
+              rollingStartNumber,
+              transmissionRiskLevel,
+              rollingPeriod,
+              regions
+            })
+          )
+
+          const result = await fetch(`${url}/upload`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              batchTag,
+              payload: await sign.update(JSON.stringify(payload), 'utf8').final()
+            })
           })
-        )
 
-        const result = await fetch(`${url}/upload`, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            batchTag,
-            payload: await sign.update(JSON.stringify(payload), 'utf8').final()
-          })
-        })
+          if (!result.ok) {
+            throw new Error(`Upload failed with ${result.status} response`)
+          }
 
-        if (!result.ok) {
-          throw new Error(`Upload failed with ${result.status} response`)
+          const { insertedExposures } = await result.json()
+
+          await insertMetric(
+            client,
+            'INTEROP_KEYS_UPLOADED',
+            '',
+            '',
+            Number(insertedExposures)
+          )
+
+          await client.query('COMMIT')
+
+          console.log(
+            `uploaded ${exposures.length} to batch ${batchTag}, ${insertedExposures} of which were stored`
+          )
+        } catch (err) {
+          await client.query('ROLLBACK')
+          throw err
         }
-
-        const { insertedExposures } = await result.json()
-
-        await insertMetric(
-          client,
-          'INTEROP_KEYS_UPLOADED',
-          '',
-          '',
-          Number(insertedExposures)
-        )
-
-        await client.query('COMMIT')
-
-        console.log(
-          `uploaded ${exposures.length} to batch ${batchTag}, ${insertedExposures} of which were stored`
-        )
-      } catch (err) {
-        await client.query('ROLLBACK')
-        throw err
       }
     }
-  }
+  })
 }
 
 runIfDev(exports.handler)

--- a/upload.js
+++ b/upload.js
@@ -99,7 +99,9 @@ exports.handler = async function() {
             },
             body: JSON.stringify({
               batchTag,
-              payload: await sign.update(JSON.stringify(payload), 'utf8').final()
+              payload: await sign
+                .update(JSON.stringify(payload), 'utf8')
+                .final()
             })
           })
 


### PR DESCRIPTION
Database connection are never close and every invocation of one of the lambda is establishing a new connection.
Connections will be closed when a lambda is finally brought down by aws, but this may take some time and cause spikes of open connections to the database.

This PR introduce a method to close connections to the db after the lambda handler is done.